### PR TITLE
Implement changeHandler and clickHandler for Navbar search

### DIFF
--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -23,6 +23,7 @@ class App extends React.Component {
     this.handleSearchChange = this.handleSearchChange.bind(this)
   }
 
+  // NOTE: Typeahead change handler works differently than a normal input field
   handleSearchChange(selected) {
     console.log(selected[0]);
     console.log('Change Handler entered')
@@ -31,6 +32,7 @@ class App extends React.Component {
 
   handleSearchSubmit() {
     console.log('You pressed the button but nothing happened')
+    console.log(`Search Term: ${this.state.searchTerm} \nReferences id: ${this.state.idDict[this.state.searchTerm]}`)
 
   }
 
@@ -49,7 +51,7 @@ class App extends React.Component {
   componentDidMount() {
     axios.get('http://localhost:3000/search')
       .then((result) => {
-        console.log(result.data);
+        // console.log(result.data);
         this.handleItems(result.data);
       })
       .catch((err) => {
@@ -58,7 +60,7 @@ class App extends React.Component {
   }
 
   render() {
-    console.log(navCats)
+    // console.log(navCats)
     return (
       <>
         <Navbar bg="light" expand="sm" className="align-items-center">
@@ -77,6 +79,7 @@ class App extends React.Component {
                 labelKey="name"
                 options={this.state.allTitles}
                 onChange={(selected) => { this.handleSearchChange(selected) }}
+                id="typeahead-search"
               />
               <InputGroup.Append>
                 {/* &#x1F50E; is another magnifying glass option*/}

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -20,18 +20,30 @@ class App extends React.Component {
       allTitles: [],
       idDict: {}
     }
+    this.handleSearchChange = this.handleSearchChange.bind(this)
+  }
+
+  handleSearchChange(selected) {
+    console.log(selected[0]);
+    console.log('Change Handler entered')
+    this.setState({searchTerm: selected[0]})
+  }
+
+  handleSearchSubmit() {
+    console.log('You pressed the button but nothing happened')
+
   }
 
   handleItems(items) {
     const titleArr = [];
     const titleDict = {};
-    for(let element of items) {
+    for (let element of items) {
       titleDict[element.title] = element.listing_id;
       titleArr.push(element.title);
     }
     // console.log(titleArr);
     // console.log(titleDict);
-    this.setState({allTitles: titleArr, idDict: titleDict});
+    this.setState({ allTitles: titleArr, idDict: titleDict });
   }
 
   componentDidMount() {
@@ -64,10 +76,16 @@ class App extends React.Component {
                 aria-describedby="basic-addon2"
                 labelKey="name"
                 options={this.state.allTitles}
+                onChange={(selected) => { this.handleSearchChange(selected) }}
               />
               <InputGroup.Append>
                 {/* &#x1F50E; is another magnifying glass option*/}
-                <Button variant="outline-secondary" className="searchBtn">&#8981;</Button>
+                <Button variant="outline-secondary"
+                  className="searchBtn"
+                  onClick={()=>{this.handleSearchSubmit()}}
+                  >
+                  &#8981;
+                  </Button>
 
               </InputGroup.Append>
             </InputGroup>


### PR DESCRIPTION
Note that the Typeahead component changeHandler is different than a normal form changeHandler. Need to access the 'selected' keyword, which is actually an array of all the search terms selected (in case of multiple select forms) vs event.target.value that is typically used.